### PR TITLE
Fix decoder for slice of different but allocatable types

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -365,7 +365,7 @@ func (d *decoder) read(f field, v reflect.Value) {
 					}
 				}
 			} else {
-				v.Set(reflect.MakeSlice(f.BinaryType, alen, alen))
+				v.Set(reflect.MakeSlice(f.NativeType, alen, alen))
 				fixed()
 			}
 		default:

--- a/packing_test.go
+++ b/packing_test.go
@@ -292,6 +292,31 @@ func TestUnpack(t *testing.T) {
 		},
 		{
 			data: []byte{
+				0x00, 0x00, 0x00, 0x03,
+			},
+			bitsize: 32,
+			value: struct {
+				Array [1]int `struct:"[1]int32"`
+			}{
+				Array: [1]int{3},
+			},
+		},
+		{
+			data: []byte{
+				0x00, 0x00, 0x00, 0x01,
+				0x00, 0x00, 0x00, 0x03,
+			},
+			bitsize: 64,
+			value: struct {
+				Size  int `struct:"int32,sizeof=Array"`
+				Array []int `struct:"[]int32"`
+			}{
+				Size:  1,
+				Array: []int{3},
+			},
+		},
+		{
+			data: []byte{
 				0x00, 0x00, 0x00, 0x01,
 				0x00, 0x00, 0x00, 0x03,
 			},


### PR DESCRIPTION
If a slice field has binary type specified by struct tag and that is different from native type but allocatable, decoder fails to set the slice field because it tries to make a slice of binary type and set to the field that has native type.