### PR TITLE
Fix decode from array to slice with different but allocatable types

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -286,7 +286,7 @@ func (d *decoder) read(f field, v reflect.Value) {
 
 		// If the underlying value is a slice, initialize it.
 		if f.NativeType.Kind() == reflect.Slice {
-			v.Set(reflect.MakeSlice(reflect.SliceOf(f.BinaryType.Elem()), l, l))
+			v.Set(reflect.MakeSlice(reflect.SliceOf(f.NativeType.Elem()), l, l))
 		}
 
 		switch f.NativeType.Kind() {

--- a/packing_test.go
+++ b/packing_test.go
@@ -317,6 +317,17 @@ func TestUnpack(t *testing.T) {
 		},
 		{
 			data: []byte{
+				0x00, 0x00, 0x00, 0x03,
+			},
+			bitsize: 32,
+			value: struct {
+				Array []int `struct:"[1]int32"`
+			}{
+				Array: []int{3},
+			},
+		},
+		{
+			data: []byte{
 				0x00, 0x00, 0x00, 0x01,
 				0x00, 0x00, 0x00, 0x03,
 			},


### PR DESCRIPTION
This fix is almost same as https://github.com/go-restruct/restruct/pull/37. Fixed `array -> slice` situation.