### PR TITLE
Fix bitpacking edge case behaviors.

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -49,10 +49,18 @@ func (e *encoder) writeBits(f field, inBuf []byte) {
 		encodedBits = 8 * len(inBuf)
 	} else {
 		encodedBits = int(e.bitSize)
-	}
 
-	// Crop input buffer to relevant bytes only.
-	inBuf = inBuf[len(inBuf)-(encodedBits+7)/8:]
+		// HACK: Go's generic endianness abstraction is not great if you are
+		// working with bits directly. Here we hardcode a case for little endian
+		// because there is no other obvious way to deal with it.
+		//
+		// Crop input buffer to relevant bytes only.
+		if e.order == binary.LittleEndian {
+			inBuf = inBuf[:(encodedBits+7)/8]
+		} else {
+			inBuf = inBuf[len(inBuf)-(encodedBits+7)/8:]
+		}
+	}
 
 	if e.bitCounter == 0 && encodedBits%8 == 0 {
 		// Fast path: we are fully byte-aligned.

--- a/packing_test.go
+++ b/packing_test.go
@@ -26,7 +26,6 @@ func TestUnpack(t *testing.T) {
 				Dd: 0x12345678,
 			},
 		},
-
 		{
 			data: []byte{
 				0x55, 0x55,
@@ -42,6 +41,114 @@ func TestUnpack(t *testing.T) {
 				B: 0x02,
 				C: 0xAA,
 				D: 0x05,
+			},
+		},
+		{
+			data: []byte{
+				0x55, 0x55,
+			},
+			bitsize: 16,
+			value: struct {
+				A int8 `struct:"int8:3"`
+				B int8 `struct:"int8:2,big"`
+				C int8 `struct:"int8"`
+				D int8 `struct:"int8:3"`
+			}{
+				A: 0x02,
+				B: 0x02,
+				C: -0x56,
+				D: -0x03,
+			},
+		},
+		{
+			data: []byte{
+				0xFF, 0xFF,
+			},
+			bitsize: 16,
+			value: struct {
+				A int8 `struct:"int8:3"`
+				B int8 `struct:"int8:2"`
+				C int8 `struct:"int8"`
+				D int8 `struct:"int8:3"`
+			}{
+				A: -1,
+				B: -1,
+				C: -1,
+				D: -1,
+			},
+		},
+		{
+			data: []byte{
+				0xFF, 0xFF, 0xFF, 0xFF,
+			},
+			bitsize: 32,
+			value: struct {
+				A int32 `struct:"int32:24"`
+				B int8  `struct:"int16:8"`
+			}{A: -1, B: -1},
+		},
+		{
+			data: []byte{
+				0xFF, 0xFF, 0xFF, 0xFF,
+				0xFF, 0xFF, 0xFF, 0xFF,
+			},
+			bitsize: 64,
+			value: struct {
+				A int64 `struct:"int64:49"`
+				B int64 `struct:"int64:15"`
+			}{A: -1, B: -1},
+		},
+		{
+			data: []byte{
+				0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0x80, 0x01,
+			},
+			bitsize: 64,
+			value: struct {
+				A int64 `struct:"int64:49"`
+				B int64 `struct:"int64:15"`
+			}{A: 1, B: 1},
+		},
+		{
+			data: []byte{
+				0x0F, 0x0F, 0x0F, 0x0F,
+				0x0F, 0x0F, 0x0F, 0x0F,
+			},
+			bitsize: 64,
+			value: struct {
+				A int64 `struct:"int64:49"`
+				B int64 `struct:"int64:15"`
+			}{
+				A: 0x00001E1E1E1E1E1E,
+				B: 0x0000000000000F0F,
+			},
+		},
+		{
+			data: []byte{
+				0xAA, 0xBB, 0xCC, 0xDD,
+				0xEE, 0xFF, 0x00, 0x11,
+			},
+			bitsize: 64,
+			value: struct {
+				A uint64 `struct:"uint64:48,little"`
+				B uint64 `struct:"uint16,little"`
+			}{
+				A: 0x0000FFEEDDCCBBAA,
+				B: 0x0000000000001100,
+			},
+		},
+		{
+			data: []byte{
+				0xAA, 0xBB, 0xCC, 0xDD,
+				0xEE, 0xFF, 0x00, 0x11,
+			},
+			bitsize: 64,
+			value: struct {
+				A int64 `struct:"int64:48,little"`
+				B int64 `struct:"int16,little"`
+			}{
+				A: -0x0000001122334456,
+				B: 0x0000000000001100,
 			},
 		},
 		{
@@ -308,7 +415,7 @@ func TestUnpack(t *testing.T) {
 			},
 			bitsize: 64,
 			value: struct {
-				Size  int `struct:"int32,sizeof=Array"`
+				Size  int   `struct:"int32,sizeof=Array"`
 				Array []int `struct:"[]int32"`
 			}{
 				Size:  1,


### PR DESCRIPTION
The current bitpacking code does very silly things when dealing with little endian and signed numbers. This PR aims to fix both and add a few tests to help ensure ongoing correctness of behaviors. 

This change is somewhat breaking, but the old behavior is so broken, that it is pretty doubtful anyone was actually relying on it. Apologies if this change breaks you. I did a cursory search of restruct usages on GitHub and did not find many users of bitpacking, especially with little endian.

Fixes #46.

### Overview: Bitpacking and Endianness
Bitpacking and endianness is a little ugly. Firstly, there are two possible meanings of "endianness" in terms of bitpacking: you can either pack bits and then byteswap, or byteswap and then bitpack. Because restruct works on individual fields that are encoded to streams of bits individually, it can't really do the former easily. The latter arguably doesn't make sense, but nonetheless, it is the only sensical way to interpret endianness from restruct's PoV. So, if you specify little endian on a bitpacked integer, the bitpacked integer itself will be byteswapped, and then packed.

If you want to handle a more complex encoding, you will need to use a custom type.

Because the Go `encoding/binary` ByteOrder is strictly dealing with byte-wise constructs, in order to know where significant bits go we need to inspect whether or not we are using `binary.LittleEndian`. This slight hack is viewed as necessary as it is the only way for data to be preserved roundtrip; prior to now, the bit encoding function actually cropped off the wrong part of the buffer, leading to data loss.

### Overview: Bitpacking and Signed Integers
Up until now, signed integers were simply not sign-extended when decoded with bitpacking. In essence, this should basically break signed integers any time they are bitpacked, because their sign bit will just be ignored.

In this PR, sign extension is added to all bitwise signed integer reads. Doing so requires some extra machinery in the decoding process, but thankfully not the encoding process; the encoding process just needs to truncate the extra bits, which is trivially done by the code that already exists.